### PR TITLE
set and export OOZIE_URL in config.ini.tpl

### DIFF
--- a/conf/config.ini.tpl
+++ b/conf/config.ini.tpl
@@ -1,3 +1,4 @@
 export OOZIE_HOSTNAME=localhost
 export OOZIE_PORT=11000
 export OOZIE_BIN=/usr/bin/oozie
+export OOZIE_URL=http://${OOZIE_HOSTNAME}:${OOZIE_PORT}/oozie


### PR DESCRIPTION
Hi Alex, ich fände es praktisch wenn man in der config gleich OOZIE_URL setzt, dann werden manuelle commandlines einfacher. Einfach source config.ini in bash aufrufen.