### PR TITLE
bundle name filter

### DIFF
--- a/bin/oozie-tool
+++ b/bin/oozie-tool
@@ -25,8 +25,8 @@ export OOZIE_TOOL_LIBEXEC_DIR="$bin"/../libexec
 usage(){
 	echo "Usage: oozie-tool COMMAND"
 	echo "where COMMAND is one of:"
-	echo "  bundles [--bundle-filter=str1,str2,...,strN]    check all bundles with status RUNNING"
-	echo "  bundle-by-id <bundle id>                        check a bundle specified by its bundle id"
+	echo "  bundles [--bundle-filter <filterstring>]    check all bundles with status RUNNING"
+	echo "  bundle-by-id <bundle id>                    check a bundle specified by its bundle id"
 	exit 1
 }
 

--- a/bin/oozie-tool
+++ b/bin/oozie-tool
@@ -25,8 +25,8 @@ export OOZIE_TOOL_LIBEXEC_DIR="$bin"/../libexec
 usage(){
 	echo "Usage: oozie-tool COMMAND"
 	echo "where COMMAND is one of:"
-	echo "  bundles                     check all bundles with status RUNNING"
-	echo "  bundle-by-id <bundle id>    check a bundle specified by its bundle id"
+	echo "  bundles [--bundle-filter=str1,str2,...,strN]    check all bundles with status RUNNING"
+	echo "  bundle-by-id <bundle id>                        check a bundle specified by its bundle id"
 	exit 1
 }
 
@@ -39,20 +39,15 @@ shift
 
 # support help commands
 case $COMMAND in
+	bundles)
+		shift
+		exec "${OOZIE_TOOL_LIBEXEC_DIR}/getRunningBundles.sh" "$@"
+		;;
+	bundle-by-id)
+		exec "${OOZIE_TOOL_LIBEXEC_DIR}/getCoordinatorsByBundleID.sh" "$@"
+		;;
 	# usage flags
 	--help|-help|-h|help)
-	usage
-	;;
+		usage
+		;;
 esac
-
-# figure out which tool to run
-if [ "$COMMAND" = "bundles" ] ; then
-	TOOL='getRunningBundles'
-elif [ "$COMMAND" = "bundle-by-id" ] ; then
-	TOOL='getCoordinatorsByBundleID'
-else
-	usage
-fi
-
-# run it
-exec "${OOZIE_TOOL_LIBEXEC_DIR}/$TOOL.sh" "$@"

--- a/libexec/getCoordinatorsByBundleID.sh
+++ b/libexec/getCoordinatorsByBundleID.sh
@@ -24,6 +24,7 @@ usage(){
 [[ $# -ne 1 ]] && usage
 
 OOZIE_BUNDLE_ID=$1
+BUNDLE_FILTER=$2
 
 if [ ! -f "${OOZIE_TOOL_CONF_DIR}/config.ini" ]; then
 	echo "config.ini not found!"
@@ -33,6 +34,9 @@ source "${OOZIE_TOOL_CONF_DIR}/config.ini"
 
 # print currently checked bundle name
 OOZIE_BUNDLE_NAME=$(${OOZIE_BIN} job -oozie http://${OOZIE_HOSTNAME}:${OOZIE_PORT}/oozie -info ${OOZIE_BUNDLE_ID} | grep "Job Name" | awk '{print $4}')
+if [ "${OOZIE_BUNDLE_NAME}" =~ "${BUNDLE_FILTER}" ]; then
+	exit 0
+fi
 echo -e "\e[00;34mChecking: ${OOZIE_BUNDLE_NAME} (${OOZIE_BUNDLE_ID})\e[00m"
 echo "--------------------------------------------------------------------------------"
 

--- a/libexec/getCoordinatorsByBundleID.sh
+++ b/libexec/getCoordinatorsByBundleID.sh
@@ -21,7 +21,7 @@ usage(){
 }
 
 # check for parameter (bundle id)
-[[ $# -ne 1 ]] && usage
+[[ $# -lt 1 ]] && usage
 
 OOZIE_BUNDLE_ID=$1
 BUNDLE_FILTER=$2
@@ -34,7 +34,7 @@ source "${OOZIE_TOOL_CONF_DIR}/config.ini"
 
 # print currently checked bundle name
 OOZIE_BUNDLE_NAME=$(${OOZIE_BIN} job -oozie http://${OOZIE_HOSTNAME}:${OOZIE_PORT}/oozie -info ${OOZIE_BUNDLE_ID} | grep "Job Name" | awk '{print $4}')
-if [ "${OOZIE_BUNDLE_NAME}" =~ "${BUNDLE_FILTER}" ]; then
+if [[ "${OOZIE_BUNDLE_NAME}" == *"${BUNDLE_FILTER}"* ]]; then
 	exit 0
 fi
 echo -e "\e[00;34mChecking: ${OOZIE_BUNDLE_NAME} (${OOZIE_BUNDLE_ID})\e[00m"

--- a/libexec/getRunningBundles.sh
+++ b/libexec/getRunningBundles.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+BUNDLE_FILTER=$1
+
 if [ ! -f "${OOZIE_TOOL_CONF_DIR}/config.ini" ]; then
 	echo "config.ini not found!"
 	exit 2
@@ -26,5 +28,5 @@ OOZIE_RUNNING_BUNDLES=$(${OOZIE_BIN} jobs -oozie http://${OOZIE_HOSTNAME}:${OOZI
 # run script for getting the coordinators for each bundle
 for bid in ${OOZIE_RUNNING_BUNDLES[@]}
 do
-	${OOZIE_TOOL_LIBEXEC_DIR}/getCoordinatorsByBundleID.sh ${bid}
+	${OOZIE_TOOL_LIBEXEC_DIR}/getCoordinatorsByBundleID.sh ${bid} ${BUNDLE_FILTER}
 done


### PR DESCRIPTION
added ```--bundle-filter``` option to filter bundles out by a string that is contained in the bundle name.

Usage: ```bin/oozie-tool bundles --bundle-filter <filter string>```